### PR TITLE
additional information in logs

### DIFF
--- a/src/Internal/PartitionStateChangeEvent.cs
+++ b/src/Internal/PartitionStateChangeEvent.cs
@@ -38,5 +38,10 @@ namespace kafka4net.Internal
                 return hash;
             }
         }
+
+        public override string ToString()
+        {
+            return string.Format("PartitionStateChangeEvent: '{0}'/{1}/{2}", Topic, PartitionId, ErrorCode);
+        }
     }
 }


### PR DESCRIPTION
More informative messages in logs.
PartitionStateChangeEvent.ToString is overriden to make `var msg = string.Format("Send Buffer Full for partition {0}. "...` more readable (currently it looks like "Send Buffer Full for partition kafka4net.Internal.PartitionStateChangeEvent" without any information about topic/partition)